### PR TITLE
Work around 'from ucam_webauth.raven import *' being broken under Py2

### DIFF
--- a/raven/__init__.py
+++ b/raven/__init__.py
@@ -1,1 +1,1 @@
-from ucam_webauth.raven import *
+from ucam_webauth.raven import PUBKEY2, RAVEN_AUTH, RAVEN_LOGOUT, Request, Response

--- a/raven/demoserver.py
+++ b/raven/demoserver.py
@@ -1,1 +1,1 @@
-from ucam_webauth.raven.demoserver import *
+from ucam_webauth.raven.demoserver import PUBKEY901, RAVEN_DEMO_AUTH, RAVEN_DEMO_LOGOUT, Request, Response

--- a/raven/flask_glue.py
+++ b/raven/flask_glue.py
@@ -1,1 +1,1 @@
-from ucam_webauth.raven.flask_glue import *
+from ucam_webauth.raven.flask_glue import AuthDecorator


### PR DESCRIPTION
`ucam_webauth.__all__` (etc.) is broken in Python 2 due to `from __future__ import unicode_literals` (Python 2 expects `__all__` to be a list of non-unicode strings).

Fixing that in ucam_webauth would be tedious, and we can not care after 31st December in theory, but we may as well not `import *` ourselves in the compatibility wrapper.